### PR TITLE
Support of string pointers in blob-lang expressions

### DIFF
--- a/pkg/expression/expression.go
+++ b/pkg/expression/expression.go
@@ -51,6 +51,8 @@ func EvalExpression(expr *Expression, msg protoreflect.Message) (result string, 
 			switch v := x.(type) {
 			case string:
 				id.WriteString(v)
+			case *string:
+				id.WriteString(*v)
 			case []byte:
 				id.Write(v)
 			default:

--- a/test/simple/main.go
+++ b/test/simple/main.go
@@ -201,6 +201,20 @@ func (wf *someWorkflow4) Execute(ctx workflow.Context) (resp *commonv1.Paginated
 
 // ============================================================================
 
+type someWorkflow5 struct {
+	*simplepb.SomeWorkflow5WorkflowInput
+}
+
+func (w *Workflows) SomeWorkflow5(ctx workflow.Context, input *simplepb.SomeWorkflow5WorkflowInput) (simplepb.SomeWorkflow5Workflow, error) {
+	return &someWorkflow5{input}, nil
+}
+
+func (wf *someWorkflow5) Execute(ctx workflow.Context) error {
+	return nil
+}
+
+// ============================================================================
+
 type Activities struct{}
 
 var ActivityEvents []string

--- a/test/simple/main_test.go
+++ b/test/simple/main_test.go
@@ -305,6 +305,24 @@ func TestSomeWorkflow4C(t *testing.T) {
 	}
 }
 
+func TestSomeWorkflow5(t *testing.T) {
+	require := require.New(t)
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	c := simplepb.NewTestSimpleClient(env, &Workflows{}, &Activities{})
+	err := c.SomeWorkflow5(context.Background(), &simplepb.SomeWorkflow5Request{
+		Id: proto.String("foo"),
+	})
+	require.NoError(err)
+
+	env = suite.NewTestWorkflowEnvironment()
+	c = simplepb.NewTestSimpleClient(env, &Workflows{}, &Activities{})
+	err = c.SomeWorkflow5(context.Background(), &simplepb.SomeWorkflow5Request{
+		Id: nil,
+	})
+	require.ErrorContains(err, "expected string result")
+}
+
 func TestCli(t *testing.T) {
 	require := require.New(t)
 	app, err := newCli()

--- a/test/simple/proto/test/simple/v1/simple.proto
+++ b/test/simple/proto/test/simple/v1/simple.proto
@@ -72,6 +72,11 @@ service Simple {
     option (temporal.v1.workflow) = {id: 'some-workflow-4/${! uuid_v4() }'};
   }
 
+  // SomeWorkflow5 does some workflow thing.
+  rpc SomeWorkflow5(SomeWorkflow5Request) returns (google.protobuf.Empty) {
+    option (temporal.v1.workflow) = {id: 'some-workflow-5/${! id }'};
+  }
+
   // SomeActivity1 does some activity thing.
   rpc SomeActivity1(google.protobuf.Empty) returns (google.protobuf.Empty) {
     option (temporal.v1.activity) = {name: 'mycompany.simple.SomeActivity1'};
@@ -173,6 +178,10 @@ message SomeWorkflow1Response {
 message SomeWorkflow3Request {
   string id = 1;
   string request_val = 2;
+}
+
+message SomeWorkflow5Request {
+  optional string id = 1;
 }
 
 message SomeActivity2Request {


### PR DESCRIPTION
protoc-gen-go generates string pointers when a string is optional.
protoc-gen-go-temporal currently does not support string pointers in blob-lang expressions.

This PR adds support for that and add tests. Note that there is no need to check for a nil string pointer, as that is handled automatically. There is for a non-nil string pointer id and a test for a nil string pointer id.

NOTE: I did not regenerate the generated files in this PR, as the generated code used new versions and the formatting was changed quite a bit. I will leave that to you, unless you want me to do it.