### PR TITLE
Fix headers in example READMEs

### DIFF
--- a/examples/codecserver/README.md
+++ b/examples/codecserver/README.md
@@ -1,4 +1,4 @@
-# xns
+# codecserver 
 
 An example showcasing use of binary protobuf encoding alongside a codec server in order to support automatic UI decoding
 

--- a/examples/mutex/README.md
+++ b/examples/mutex/README.md
@@ -1,4 +1,4 @@
-# helloworld
+# mutex
 
 *inspired by [temporalio/samples-go/mutex](https://github.com/temporalio/samples-go/tree/main/mutex)*
 

--- a/examples/updatabletimer/README.md
+++ b/examples/updatabletimer/README.md
@@ -1,4 +1,4 @@
-# helloworld
+# updatabletimer
 
 *inspired by [temporalio/samples-go/updatabletimer](https://github.com/temporalio/samples-go/tree/main/updatabletimer)*
 


### PR DESCRIPTION
This pull request updates the titles in the `README.md` files of two example projects to better reflect their content, following the pattern in the other examples.