### PR TITLE
fix: Ensures workflowIdConflictPolicy parameter is properly set when not UNSPECIFIED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Fixed
+- [#113](https://github.com/cludden/protoc-gen-go-temporal/pull/113) fix Ensures workflowIdConflictPolicy parameter is properly set when not UNSPECIFIED
 
 
 

--- a/internal/plugin/client.go
+++ b/internal/plugin/client.go
@@ -2382,6 +2382,13 @@ func (m *Manifest) genWorkflowOptions(f *j.File, workflow protoreflect.FullName,
 				})
 			}
 
+			// set WorkflowIDConflictPolicy
+			if !child {
+				g.If(j.Id("v").Op(":=").Id("o").Dot("workflowIdConflictPolicy"), j.Id("v").Op("!=").Qual(enumsPkg, "WORKFLOW_ID_CONFLICT_POLICY_UNSPECIFIED")).Block(
+					j.Id("opts").Dot("WorkflowIDConflictPolicy").Op("=").Id("v"),
+				)
+			}
+
 			// set TaskQueue
 			g.If(j.Id("v").Op(":=").Id("o").Dot("taskQueue"), j.Id("v").Op("!=").Nil()).Block(
 				j.Id("opts").Dot("TaskQueue").Op("=").Op("*").Id("v"),


### PR DESCRIPTION
- Add WorkflowIDConflictPolicy field assignment in workflow options generation
- Only apply to non-child workflow types as child workflows don't support WorkflowIDConflictPolicy